### PR TITLE
Create the Foundation for the REST server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /venv
 __pycache__
+/trpdtrails.egg-info

--- a/README.md
+++ b/README.md
@@ -9,6 +9,23 @@ I do not work with the Three Rivers Park District of Minnesota.
 The Three Rivers Park District does not maintain this project.
 Support for this module will only last as long as I am willing and/or able to support it.
 
+## Running the Server
+```
+export FLASK_APP=trpdtrails
+```
+
+Then in order to install and run the server you need to run:
+```
+pip install -e .
+flask run
+```
+
+Additionally, development features can be seen with:
+```
+export FLASK_ENV=development
+```
+
+
 ## Unit Tests
 
 Unit Tests can be ran with:

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+from setuptools import setup
+
+setup(
+    name='trpdtrails',
+    packages=['trpdtrails'],
+    include_package_data=True,
+    install_requires=[
+        'flask'
+    ],
+)

--- a/trpdtrails/__init__.py
+++ b/trpdtrails/__init__.py
@@ -1,0 +1,5 @@
+'''trpdtrails Application Entry Point'''
+from flask import Flask
+app = Flask(__name__)
+
+import trpdtrails.routes

--- a/trpdtrails/routes.py
+++ b/trpdtrails/routes.py
@@ -1,0 +1,10 @@
+from trpdtrails import app
+import logging
+
+@app.route('/parks', methods=['GET'])
+def parks():
+    return 'This will return the list of all of the parks'
+
+@app.route('/parks/<park>', methods=['GET'])
+def get_park(park):
+    return f'This will return the information about the specific park, {park}, if it exists'


### PR DESCRIPTION
creates basic modular Flask app, separating the routes and utilities from the main app for easier development.
This should hopefully kick off migrating things away from a more 'scripty' feel and more like a server.